### PR TITLE
Add ABAP parser script using Tree-sitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# ABAP Parser Example
+
+This repository contains a small script for parsing ABAP source files using
+[Tree-sitter](https://tree-sitter.github.io/) and validating the names of
+objects against reference lists. The project is intended to be run locally on a
+single machine (Windows or other OS).
+
+## Prerequisites
+
+1. **Python 3.9+**
+2. **Node.js** (to install `tree-sitter-cli` for generating the parser)
+3. **CMake** (required by Tree-sitter when building languages)
+
+Install Python packages:
+
+```bash
+pip install tree_sitter
+```
+
+Install Tree-sitter CLI using npm:
+
+```bash
+npm install -g tree-sitter-cli
+```
+
+## Building the ABAP Parser
+
+Clone the grammar for ABAP and generate the parser:
+
+```bash
+git clone https://github.com/abaplint/tree-sitter-abap.git
+cd tree-sitter-abap
+# Generate source files
+tree-sitter generate
+cd ..
+```
+
+Build the shared library containing the ABAP grammar:
+
+```bash
+python - <<'PY'
+from tree_sitter import Language
+Language.build_library(
+    'build/my-languages.so',
+    ['tree-sitter-abap']
+)
+PY
+```
+
+After this step the file `build/my-languages.so` will contain the compiled
+Tree-sitter grammar used by the parser script.
+
+## Preparing Reference Lists
+
+Create a directory named `base` and add the following text files with one name
+per line:
+
+- `tables.txt` – valid table names
+- `classes.txt` – valid class names
+- `functions.txt` – valid function module names
+
+## Running the Script
+
+```bash
+python abap_parser.py path/to/source.abap base output.json
+```
+
+The resulting `output.json` will contain all extracted names and statistics
+about which names were not found in the reference lists.
+
+## Example JSON Result
+
+```json
+{
+  "extracted": {
+    "classes": ["ZCL_MY_CLASS"],
+    "functions": ["MY_FUNCTION"],
+    "forms": ["my_form"],
+    "tables": ["MARA", "VBAP"]
+  },
+  "statistics": {
+    "tables": {
+      "total": 2,
+      "valid": 2,
+      "invalid": 0,
+      "error_percentage": 0.0,
+      "invalid_names": []
+    },
+    "classes": { ... },
+    "functions": { ... }
+  }
+}
+```
+
+This example shows the structure of the output where `invalid_names` lists
+objects not present in the corresponding base file.

--- a/abap_parser.py
+++ b/abap_parser.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Parse ABAP code with Tree-sitter and validate object names.
+
+This script extracts tables, classes and function modules from an ABAP
+source file using the Tree-sitter grammar for ABAP. Extracted names are
+compared with reference lists stored in a directory `base` containing
+`tables.txt`, `classes.txt` and `functions.txt`.
+
+Usage:
+    python abap_parser.py SOURCE_FILE BASE_DIR OUTPUT_JSON
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+from tree_sitter import Language, Parser
+
+# Path to compiled Tree-sitter languages library
+LANG_SO = Path('build') / 'my-languages.so'
+
+# Initialise parser
+ABAP_LANGUAGE = Language(str(LANG_SO), 'abap')
+parser = Parser()
+parser.set_language(ABAP_LANGUAGE)
+
+
+def extract_objects(path: Path) -> dict[str, list[str]]:
+    """Parse ABAP source and return detected object names."""
+    code = path.read_bytes()
+    text = code.decode('utf8', errors='ignore')
+    tree = parser.parse(code)
+    root = tree.root_node
+
+    classes: set[str] = set()
+    functions: set[str] = set()
+    forms: set[str] = set()
+
+    def walk(node):
+        if node.type == 'class_definition':
+            name = node.child_by_field_name('name')
+            if name:
+                classes.add(text[name.start_byte:name.end_byte])
+        elif node.type == 'function_definition':
+            name = node.child_by_field_name('name')
+            if name:
+                functions.add(text[name.start_byte:name.end_byte])
+        elif node.type == 'form_definition':
+            name = node.child_by_field_name('name')
+            if name:
+                forms.add(text[name.start_byte:name.end_byte])
+        for child in node.children:
+            walk(child)
+
+    walk(root)
+
+    tables = set(re.findall(r"FROM\s+([A-Za-z0-9_/]+)", text, flags=re.IGNORECASE))
+
+    return {
+        'classes': sorted(classes),
+        'functions': sorted(functions),
+        'forms': sorted(forms),
+        'tables': sorted(tables),
+    }
+
+
+def load_base_list(base_dir: Path, name: str) -> set[str]:
+    """Load reference names from BASE_DIR/NAME.txt."""
+    path = base_dir / f"{name}.txt"
+    if path.is_file():
+        return {line.strip() for line in path.read_text(encoding='utf8').splitlines() if line.strip()}
+    return set()
+
+
+def compare_found(found: list[str], base: set[str]) -> dict:
+    """Compare extracted names with reference set."""
+    found_set = set(found)
+    total = len(found_set)
+    invalid = sorted(found_set - base)
+    valid = sorted(found_set & base)
+    errors = len(invalid)
+    percent = (errors / total * 100) if total > 0 else 0.0
+    return {
+        'total': total,
+        'valid': len(valid),
+        'invalid': errors,
+        'error_percentage': round(percent, 2),
+        'invalid_names': invalid,
+    }
+
+
+def main() -> None:
+    parser_cli = argparse.ArgumentParser(description='Parse ABAP and validate object names.')
+    parser_cli.add_argument('source', help='path to ABAP source file')
+    parser_cli.add_argument('base_dir', help='directory with tables.txt/classes.txt/functions.txt')
+    parser_cli.add_argument('output', help='JSON file for results')
+    args = parser_cli.parse_args()
+
+    base_path = Path(args.base_dir)
+    extracted = extract_objects(Path(args.source))
+
+    base_sets = {
+        'tables': load_base_list(base_path, 'tables'),
+        'classes': load_base_list(base_path, 'classes'),
+        'functions': load_base_list(base_path, 'functions'),
+    }
+
+    stats = {category: compare_found(extracted[category], base_sets.get(category, set()))
+             for category in base_sets.keys()}
+
+    result = {
+        'extracted': extracted,
+        'statistics': stats,
+    }
+
+    Path(args.output).write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding='utf8')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script `abap_parser.py` that parses ABAP code via Tree-sitter
- document installation and usage in `README.md`

## Testing
- `pip install --upgrade tree_sitter`
- `git clone https://github.com/abaplint/tree-sitter-abap.git` *(fails: asks for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6877efb4fc088320be3189b2c572ba03