### PR TITLE
Add ABAP parser sample and tests

### DIFF
--- a/abap_parser.py
+++ b/abap_parser.py
@@ -1,0 +1,36 @@
+import re
+import json
+from typing import Dict, List, Tuple
+
+def parse_abap_file(path: str) -> Dict[str, int]:
+    counts = {'class': 0, 'form': 0, 'function': 0}
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line_up = line.strip().upper()
+            if line_up.startswith('CLASS ') and 'DEFINITION' in line_up:
+                counts['class'] += 1
+            elif line_up.startswith('FORM '):
+                counts['form'] += 1
+            elif line_up.startswith('FUNCTION '):
+                counts['function'] += 1
+    return counts
+
+def parse_object_base(path: str) -> List[Tuple[str, str]]:
+    objects = []
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) >= 2:
+                name, obj_type = parts[0], parts[1]
+                objects.append((name, obj_type))
+    return objects
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) != 3:
+        print('Usage: python abap_parser.py <abap_file> <object_base>')
+        sys.exit(1)
+    counts = parse_abap_file(sys.argv[1])
+    objs = parse_object_base(sys.argv[2])
+    print('Counts:', json.dumps(counts))
+    print('Objects:', json.dumps(objs))

--- a/object_base.txt
+++ b/object_base.txt
@@ -1,0 +1,3 @@
+CL_EXAMPLE class
+ZFUNC_EXAMPLE function
+ZREPORT_EXAMPLE report

--- a/sample.abap
+++ b/sample.abap
@@ -1,0 +1,20 @@
+REPORT zexample.
+
+FORM hello_world.
+  WRITE 'Hello, world!'.
+ENDFORM.
+
+CLASS lcl_example DEFINITION.
+  PUBLIC SECTION.
+    METHODS: run.
+ENDCLASS.
+
+CLASS lcl_example IMPLEMENTATION.
+  METHOD run.
+    PERFORM hello_world.
+  ENDMETHOD.
+ENDCLASS.
+
+START-OF-SELECTION.
+  DATA(lo_obj) = NEW lcl_example().
+  lo_obj->run( ).

--- a/test_parser.py
+++ b/test_parser.py
@@ -1,0 +1,18 @@
+import unittest
+from abap_parser import parse_abap_file, parse_object_base
+
+class TestAbapParser(unittest.TestCase):
+    def test_parse_abap_file(self):
+        counts = parse_abap_file('sample.abap')
+        self.assertEqual(counts['form'], 1)
+        self.assertEqual(counts['class'], 1)
+        self.assertEqual(counts['function'], 0)
+
+    def test_parse_object_base(self):
+        objects = parse_object_base('object_base.txt')
+        self.assertIn(('CL_EXAMPLE', 'class'), objects)
+        self.assertIn(('ZFUNC_EXAMPLE', 'function'), objects)
+        self.assertIn(('ZREPORT_EXAMPLE', 'report'), objects)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add sample ABAP program `sample.abap`
- provide ABAP object base file
- create simple parser `abap_parser.py`
- add unit tests for parser

## Testing
- `python3 -m unittest test_parser.py`
- `python3 abap_parser.py sample.abap object_base.txt`


------
https://chatgpt.com/codex/tasks/task_e_6877f22bb33083209851a23212dc5083